### PR TITLE
allow to set a null schedule

### DIFF
--- a/dev/src/main/java/com/kenai/redminenb/issue/RedmineIssue.java
+++ b/dev/src/main/java/com/kenai/redminenb/issue/RedmineIssue.java
@@ -354,7 +354,11 @@ public final class RedmineIssue {
         if(issue == null) {
             return; // Silently igonre setSchedule on not yet saved issues
         }
-        issue.setStartDate(scheduleInfo.getDate());
+        if (scheduleInfo == null) {
+            issue.setStartDate(null);
+        } else {
+            issue.setStartDate(scheduleInfo.getDate());
+        }
         try {
             getRepository().getIssueManager().update(issue);
         } catch (RedmineException | RuntimeException ex) {


### PR DESCRIPTION
When left clicking on a task in the Tasks view, Repositories and choosing *Schedule for* -> *Not schedule* it used to not work. Fixed to work.